### PR TITLE
ThriftContext now supports iterators

### DIFF
--- a/src/EncodingContext.cpp
+++ b/src/EncodingContext.cpp
@@ -9,31 +9,114 @@ namespace cppkin
 {
     EncoderContext::~EncoderContext() {}
 
+
+    EncoderContextThrift::ContextElement::ContextElement(reference span, protocol& _protocol, buffer& _buffer):
+            m_span(new ::Span(span)), m_protocol(_protocol), m_buffer(_buffer){}
+
+    EncoderContextThrift::ContextElement::~ContextElement() {}
+
+    string EncoderContextThrift::ContextElement::ToString() const{
+        m_buffer.resetBuffer();
+        m_span->write(&m_protocol);
+        return m_buffer.getBufferAsString();
+    }
+
+    EncoderContextThrift::ContextElement::reference EncoderContextThrift::ContextElement::operator*() const{
+        return *m_span;
+    }
+    EncoderContextThrift::ContextElement::pointer EncoderContextThrift::ContextElement::operator->() const{
+        return m_span.get();
+    }
+
+
+    EncoderContextThrift::EncoderContextThriftIterator::EncoderContextThriftIterator(const std::list<ContextElement>::iterator& it)
+            :m_it(it){}
+
+    EncoderContextThrift::EncoderContextThriftIterator::~EncoderContextThriftIterator(){}
+
+    EncoderContextThrift::EncoderContextThriftIterator::reference EncoderContextThrift::EncoderContextThriftIterator::operator*() const{
+        return *m_it;
+    }
+
+    EncoderContextThrift::EncoderContextThriftIterator::pointer EncoderContextThrift::EncoderContextThriftIterator::operator->() const{
+        return m_it.operator->();
+    }
+
+    EncoderContextThrift::EncoderContextThriftIterator::self& EncoderContextThrift::EncoderContextThriftIterator::operator++(int){
+        m_it++;
+        return *this;
+    }
+
+    bool EncoderContextThrift::EncoderContextThriftIterator::operator==(const self& obj) const{
+        return m_it == obj.m_it;
+    }
+
+    bool EncoderContextThrift::EncoderContextThriftIterator::operator!=(const self& obj) const{
+        return m_it != obj.m_it;
+    }
+
+
+    EncoderContextThrift::EncoderContextThriftConstIterator::EncoderContextThriftConstIterator(const std::list<ContextElement>::const_iterator& it)
+            :m_it(it){}
+
+    EncoderContextThrift::EncoderContextThriftConstIterator::~EncoderContextThriftConstIterator(){}
+
+    EncoderContextThrift::EncoderContextThriftConstIterator::reference EncoderContextThrift::EncoderContextThriftConstIterator::operator*() const{
+        return *m_it;
+    }
+
+    EncoderContextThrift::EncoderContextThriftConstIterator::pointer EncoderContextThrift::EncoderContextThriftConstIterator::operator->() const{
+        return m_it.operator->();
+    }
+
+    EncoderContextThrift::EncoderContextThriftConstIterator::self& EncoderContextThrift::EncoderContextThriftConstIterator::operator++(int){
+        m_it++;
+        return *this;
+    }
+
+    bool EncoderContextThrift::EncoderContextThriftConstIterator::operator==(const self& obj) const{
+        return m_it == obj.m_it;
+    }
+
+    bool EncoderContextThrift::EncoderContextThriftConstIterator::operator!=(const self& obj) const{
+        return m_it != obj.m_it;
+    }
+
     EncoderContextThrift::~EncoderContextThrift() {}
 
     EncoderContextThrift::EncoderContextThrift(): m_buffer(new transport::TMemoryBuffer()) {
         m_protocol.reset(new protocol::TBinaryProtocol(m_buffer));
     }
+
     EncoderContextThrift::EncoderContextThrift(const char* buf, uint32_t sz): m_buffer(new transport::TMemoryBuffer(const_cast<uint8_t*>((uint8_t*)buf), sz)) {
         m_protocol.reset(new protocol::TBinaryProtocol(m_buffer));
     }
 
-    string EncoderContextThrift::ToString( bool asList ){
+    EncoderContextThrift::iterator EncoderContextThrift::begin(){
+        return iterator(m_spans.begin());
+    }
 
-        if ( asList ) {
-            m_protocol->writeListBegin(protocol::T_STRUCT, m_spans.size());
+    EncoderContextThrift::iterator EncoderContextThrift::end(){
+        return iterator(m_spans.end());
+    }
 
-            for (auto &span : m_spans)
-            {
-                span.write(m_protocol.get());
-            }
+    EncoderContextThrift::const_iterator EncoderContextThrift::begin() const{
+        return const_iterator(m_spans.begin());
+    }
 
-            m_protocol->writeListEnd();
-            return m_buffer->getBufferAsString();
+    EncoderContextThrift::const_iterator EncoderContextThrift::end() const{
+        return const_iterator(m_spans.end());
+    }
+
+    string EncoderContextThrift::ToString(){
+        m_buffer->resetBuffer();
+        m_protocol->writeListBegin(protocol::T_STRUCT, m_spans.size());
+        for (auto &span : m_spans)
+        {
+            span->write(m_protocol.get());
         }
 
-        m_spans.front().write(m_protocol.get());
-        m_spans.pop_front();
+        m_protocol->writeListEnd();
         return m_buffer->getBufferAsString();
     }
 
@@ -44,6 +127,6 @@ namespace cppkin
     }
 
     void EncoderContextThrift::AddSpan(const ::Span &thriftSpan){
-        m_spans.emplace_back(thriftSpan);
+        m_spans.emplace_back(const_cast<::Span&>(thriftSpan), *m_protocol, *m_buffer);
     }
 }

--- a/src/EncodingContext.h
+++ b/src/EncodingContext.h
@@ -21,23 +21,97 @@ namespace cppkin
     {
     public:
         virtual ~EncoderContext();
-        virtual std::string ToString( bool ) = 0;
+        virtual std::string ToString() = 0;
     };
 
     class EncoderContextThrift : public EncoderContext
     {
+
+    private:
+        class ContextElement
+        {
+        public:
+            typedef ::Span* pointer;
+            typedef ::Span& reference;
+            typedef apache::thrift::protocol::TBinaryProtocol protocol;
+            typedef apache::thrift::transport::TMemoryBuffer buffer;
+
+            ContextElement(reference span, protocol& _protocol, buffer& _buffer);
+            ~ContextElement();
+            ContextElement(const ContextElement& obj) = delete;
+            ContextElement& operator=(const ContextElement& obj) = delete;
+            std::string ToString() const;
+
+            reference operator*() const;
+            pointer operator->() const;
+        private:
+            std::unique_ptr<::Span> m_span;
+            protocol& m_protocol;
+            buffer& m_buffer;
+        };
+
     public:
+        class EncoderContextThriftIterator
+        {
+        public:
+            typedef EncoderContextThriftIterator self;
+            typedef ContextElement* pointer;
+            typedef ContextElement& reference;
+
+            EncoderContextThriftIterator(const std::list<ContextElement>::iterator& it);
+            ~EncoderContextThriftIterator();
+            reference operator*() const;
+            pointer operator->() const;
+            self& operator++(int);
+            bool operator==(const self& obj) const;
+            bool operator!=(const self& obj) const;
+
+
+        private:
+            std::list<ContextElement>::iterator m_it;
+        };
+
+
+        class EncoderContextThriftConstIterator
+        {
+        public:
+            typedef EncoderContextThriftConstIterator self;
+            typedef const ContextElement* pointer;
+            typedef const ContextElement& reference;
+
+            EncoderContextThriftConstIterator(const std::list<ContextElement>::const_iterator& it);
+            ~EncoderContextThriftConstIterator();
+            reference operator*() const;
+            pointer operator->() const;
+            self& operator++(int);
+            bool operator==(const self& obj) const;
+            bool operator!=(const self& obj) const;
+
+
+        private:
+            std::list<ContextElement>::const_iterator m_it;
+        };
+
+    public:
+        typedef EncoderContextThriftIterator iterator;
+        typedef EncoderContextThriftConstIterator const_iterator;
+
         EncoderContextThrift();
         EncoderContextThrift(const char* buf, uint32_t sz);
         virtual ~EncoderContextThrift();
-        std::string ToString( bool asList = false );
+        iterator begin();
+        iterator end();
+        const_iterator begin() const;
+        const_iterator end() const;
+        std::string ToString();
         ::Span ToSpan();
 
     private:
         friend class Encoder<EncodingTypes::Thrift>;
         void AddSpan(const ::Span& thriftSpan);
+
     private:
-        std::list<::Span> m_spans;
+        std::list<ContextElement> m_spans;
         std::unique_ptr<apache::thrift::protocol::TBinaryProtocol> m_protocol;
         boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> m_buffer;
     };

--- a/src/HttpTransport.cpp
+++ b/src/HttpTransport.cpp
@@ -24,7 +24,7 @@ namespace cppkin
             Encoder<EncodingTypes::Thrift>::Serialize(context, *span);
         }
 
-        string buffer = context.ToString( true );
+        string buffer = context.ToString();
         try {
 
             CURL* curl = curl_easy_init();

--- a/src/ScribeTransport.cpp
+++ b/src/ScribeTransport.cpp
@@ -28,9 +28,14 @@ namespace cppkin
         using Entry = scribe::thrift::LogEntry;
         vector<Entry> entries;
 
-        for(Span* span : spans){
+        for(Span* span : spans) {
             Encoder<EncodingTypes::Thrift>::Serialize(context, *span);
-            string buffer = base64EncodeText(context.ToString());
+        }
+
+        auto it = context.begin();
+        while(it != context.end()) {
+            string buffer = base64EncodeText(it->ToString());
+            it++;
 
             Entry entry;
             entry.__set_category("zipkin");


### PR DESCRIPTION
fixes #9, as requested, ThriftContext now supports iterators, making scribe encoding code more elegant.

Now a context can encode its internal state in two manners - as a list (when addressing the context as a whole), or as a single element when acting upon it as range.