### PR TITLE
Update to quickstart script in example README

### DIFF
--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -3,7 +3,7 @@
 Start Zipking server
 -------------------
 
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+curl -sSL https://zipkin.io/quickstart.sh | bash -s
 
 java -jar zipkin.jar
 


### PR DESCRIPTION
The Zipkin Server group coordinates have changed in the latest versions of the Zipkin Server, so the previous download instructions would not download the latest Zipkin Server. The quickstart script provided by Zipkin will download the latest server.
See https://github.com/openzipkin/openzipkin.github.io/issues/136